### PR TITLE
Fix a couple of bugs that prevented me from compiling and crashed on screenshot creation

### DIFF
--- a/example/ios/Flutter/Debug.xcconfig
+++ b/example/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/example/ios/Flutter/Release.xcconfig
+++ b/example/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,0 +1,41 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '11.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/lib/generated/screens/screens.dart
+++ b/lib/generated/screens/screens.dart
@@ -109,6 +109,7 @@ const List<ScreenInfo> screens = [
     [
       'iPad Pro (12.9-inch) (3rd generation)',
       'iPad Pro (12.9-inch) (4th generation)',
+      'iPad Pro (12.9-inch) (6th generation)',
     ],
     statusbar: i10.r,
     statusbarBlack: i10.r,

--- a/lib/generated/screens/screens.dart
+++ b/lib/generated/screens/screens.dart
@@ -139,9 +139,7 @@ const List<ScreenInfo> screens = [
     "80%",
     "-3+8",
     "phone",
-    [
-      'Nexus 6P',
-    ],
+    ['Nexus 6P', 'Pixel 4'],
     statusbar: i16.r,
     statusbarBlack: i16.r,
     statusbarWhite: i16.r,
@@ -171,10 +169,7 @@ const List<ScreenInfo> screens = [
     null,
     null,
     "phone",
-    [
-      'default phone',
-      'Nexus 6',
-    ],
+    ['default phone', 'Nexus 6', 'Pixel 4'],
   ),
   ScreenInfo(
     DeviceType.android,

--- a/lib/screens/screens.yaml
+++ b/lib/screens/screens.yaml
@@ -1,19 +1,19 @@
 ios:
-#  4.0inch:
-#    devices:
-#      - iPhone 5
-#      - iPhone 5c
-#      - iPhone 5S
-#      - iPhone SE
-#      - iPhone iPod Touch (5th generation)
-#      - iPhone iPod Touch (6th generation)
-#      - iPhone iPod Touch (7th generation)
-#  4.7inch:
-#    devices:
-#      - iPhone 6
-#      - iPhone 6S
-#      - iPhone 7
-#      - iPhone 8
+  #  4.0inch:
+  #    devices:
+  #      - iPhone 5
+  #      - iPhone 5c
+  #      - iPhone 5S
+  #      - iPhone SE
+  #      - iPhone iPod Touch (5th generation)
+  #      - iPhone iPod Touch (6th generation)
+  #      - iPhone iPod Touch (7th generation)
+  #  4.7inch:
+  #    devices:
+  #      - iPhone 6
+  #      - iPhone 6S
+  #      - iPhone 7
+  #      - iPhone 8
   5.5inch:
     size: 1242x2208
     resize: 75%
@@ -42,9 +42,9 @@ ios:
       - iPhone X
       - iPhone XS
       - iPhone Xs
-#  6.1inch:
-#    devices:
-#      - iPhone XR
+  #  6.1inch:
+  #    devices:
+  #      - iPhone XR
   6.5inch:
     size: 1242x2688
     resize: 87%
@@ -64,27 +64,27 @@ ios:
       - iPhone 12 Pro Max
       - iPhone 13 Pro Max
       - iPhone 14 Plus
-#  7.9inches:
-#    devices:
-#      - iPad Mini
-#      - iPad Mini 2
-#      - iPad Mini 3
-#      - iPad Mini 4
-#      - iPad Mini 5
-#  9.7inch:
-#    devices:
-#      - iPad (1st generation)
-#      - iPad 2
-#      - iPad (3rd generation)
-#      - iPad (4th generation)
-#      - iPad (5th generation)
-#      - iPad (6th generation)
-#      - iPad Air
-#      - iPad Air 2
-#      - iPad Pro
-#  10.5inch:
-#    devices:
-#      - iPad Pro (10.5-inch) (1st generation)
+  #  7.9inches:
+  #    devices:
+  #      - iPad Mini
+  #      - iPad Mini 2
+  #      - iPad Mini 3
+  #      - iPad Mini 4
+  #      - iPad Mini 5
+  #  9.7inch:
+  #    devices:
+  #      - iPad (1st generation)
+  #      - iPad 2
+  #      - iPad (3rd generation)
+  #      - iPad (4th generation)
+  #      - iPad (5th generation)
+  #      - iPad (6th generation)
+  #      - iPad Air
+  #      - iPad Air 2
+  #      - iPad Pro
+  #  10.5inch:
+  #    devices:
+  #      - iPad Pro (10.5-inch) (1st generation)
   12.9inch:
     size: 2048x2732
     resize: 86%
@@ -123,8 +123,8 @@ android:
     destName: phone
     devices:
       - Nexus 5X
-#     destName: sevenInch
-#     destName: tenInch
+  #     destName: sevenInch
+  #     destName: tenInch
   5.7inch:
     size: 1440x2560
     resize: 80%
@@ -138,6 +138,7 @@ android:
     destName: phone
     devices:
       - Nexus 6P
+      - Pixel 4
   8.9inch:
     size: 1536x2048
     resize: 80%

--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -201,7 +201,7 @@ class Config {
 
     devices.forEach((deviceType, device) {
       device?.forEach((deviceName, deviceProps) {
-        if (deviceProps != null && !deviceProps is Map<String, dynamic>) {
+        if (deviceProps != null && !(deviceProps is Map<String, dynamic>)) {
           throw ConfigException("Invalid value for device '$deviceName'");
         }
 

--- a/lib/src/daemon_client.dart
+++ b/lib/src/daemon_client.dart
@@ -251,9 +251,9 @@ List<Map<String, String>> getIosDevices() {
     return [];
   }
   return iosDeployDevices.map((line) {
-    final matches = regExp.firstMatch(line)!;
+    final matches = regExp.firstMatch(line);
     final device = <String, String>{};
-    device['id'] = matches.group(1)!;
+    device['id'] = matches!.group(1)!;
     device['model'] = matches.group(2)!;
     return device;
   }).toList();

--- a/lib/src/run.dart
+++ b/lib/src/run.dart
@@ -321,7 +321,7 @@ class Screenshots {
                 case DeviceType.ios:
                   if (currentDevice.emulator) {
                     changeDeviceOrientation(d.deviceType, orientation,
-                        scriptDir: '${config.stagingDir}/resources/script');
+                        scriptDir: '${config.stagingDir}/script');
                   } else {
                     printStatus(
                         'Warning: cannot change orientation of a real iOS device.');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: screenshots
 description: Auto-generation of screenshots for Apple and Play Stores using emulators, simulators and real devices. Includes support for multiple locales and framing. Compatible with fastlane.
-version: 3.1.0
+version: 3.1.1
 homepage: https://github.com/mmcc007/screenshots
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,37 +1,36 @@
 name: screenshots
 description: Auto-generation of screenshots for Apple and Play Stores using emulators, simulators and real devices. Includes support for multiple locales and framing. Compatible with fastlane.
-version: 3.0.0
+version: 3.1.0
 homepage: https://github.com/mmcc007/screenshots
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   args: ^2.3.0
   yaml: ^3.1.0
-#  resource: ^2.1.7
+  #  resource: ^2.1.7
   path: ^1.8.0
   file: ^6.1.2
   archive: ^3.1.2
   platform: ^3.0.0
   process: ^4.2.3
   meta: ^1.7.0
-#  intl: any # ">=0.15.0 <1.0.0"
-#  tool_mobile: ^2.0.0
+  #  intl: any # ">=0.15.0 <1.0.0"
+  #  tool_mobile: ^2.0.0
   build: ^2.1.1
   tool_mobile:
     git: https://github.com/claudius-kienle/tool_mobile
   tool_base:
     git: https://github.com/trygvis/tool_base
 
-
 dev_dependencies:
   build_runner: ^2.1.4
   test: ^1.19.2
-#  test_api: ^0.2.5
+  #  test_api: ^0.2.5
   mockito: ^5.0.16
   pedantic: ^1.8.0+1
-  quiver: '>=2.0.0 <3.0.0'
+  quiver: ">=2.0.0 <3.0.0"
   fake_process_manager: ^0.2.0
   collection: any
   integration_test:


### PR DESCRIPTION
Hey Claudius, 

thanks for putting in so much work to make the screenshots tool work again! I ran into a bunch of minor issues with your PR as well but managed to make it work - even more reliably than it was from the original repo!

I wanted to share my updates for you, maybe you consider them useful. I'll from now on work with my own fork until some better tool shows up along the road or some active maintenance of the original screenshots tool happens.

Besides that my PR adds support to the 12.9 inch 6th generation iPad Pro (required to submit screenshots and fixes a couple of minor bugs.

One open issue I discovered is when I have a physical iPhone connected to the Mac, usually everything crashes. I didn't take the time to fix it, but I guess it would just be needed to filter it out.


Btw, I had to add this to my Runner's AppDelegate file to get around the screenshots issue, but that worked easily for me. Import `integration_test` and do the IntegrationTestPlugin Channel setup and it works just fine:

```
import UIKit
import Flutter
import integration_test

@UIApplicationMain
@objc class AppDelegate: FlutterAppDelegate {
    override func application(
        _ application: UIApplication,
        didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?
    ) -> Bool {
        
        
        let controller : FlutterViewController = window?.rootViewController as! FlutterViewController
        
        IntegrationTestPlugin.instance().setupChannels(controller.binaryMessenger)
```


                                                